### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol server implementation for Cloudflare DNS that enables AI agents to manage DNS records for your domains.
 
+<a href="https://glama.ai/mcp/servers/@gilberth/mcp-cloudflare">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@gilberth/mcp-cloudflare/badge" alt="Cloudflare DNS Server MCP server" />
+</a>
+
 ## Features
 
 - 🔍 **List DNS records** - View all or filtered DNS records
@@ -102,4 +106,4 @@ Delete a DNS record by ID.
 
 ## License
 
-MIT# mcp-cloudflare
+MIT


### PR DESCRIPTION
This PR adds a badge for the [MCP Cloudflare DNS Server](https://glama.ai/mcp/servers/@gilberth/mcp-cloudflare) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@gilberth/mcp-cloudflare">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@gilberth/mcp-cloudflare/badge" alt="Cloudflare DNS Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.